### PR TITLE
enable use with Phoenix

### DIFF
--- a/lib/jiffex.ex
+++ b/lib/jiffex.ex
@@ -5,6 +5,8 @@ defmodule Jiffex do
 
   @default_decode_options [:return_maps, :use_nil, :copy_strings]
 
+  defdelegate encode_to_iodata!(content), to: Jiffex, as: :encode!
+
   @doc """
   Decodes `json`, in case of dicts uses `Map`s.
   Returns `{:ok, result}` or `{:error, reason}`


### PR DESCRIPTION
In phoenix you can specify which Json library you want to use.
However they use it also for encoding/decoding the messages in the websockets.
The function that they use is encode_to_iodata! (which is basically encode!)
I just added a delegate and verified that it worked.

Let me know if you need more.